### PR TITLE
Refactor Fulcrum.submit

### DIFF
--- a/Sources/SwiftFulcrum/Fulcrum~Interface.swift
+++ b/Sources/SwiftFulcrum/Fulcrum~Interface.swift
@@ -13,26 +13,39 @@ extension Fulcrum {
         let request = method.createRequest(with: requestID)
         guard let payload = request.data else { throw Error.coding(.encode(nil)) }
         
-        return try await withCheckedThrowingContinuation { continuation in
-            Task {
-                do {
-                    try await self.client.insertRegularHandler(for: requestID) { @Sendable result in
-                        defer { Task { await self.client.removeRegularResponseHandler(for: requestID) } }
-                        
-                        switch result {
-                        case .success(let payload):
-                            continuation.resume(with: Result(catching: { (requestID, try payload.decode(RegularResponseResult.self)) }))
-                        case .failure(let error):
-                            continuation.resume(throwing: Error.client(.unknown(error)))
-                        }
-                    }
-                    try await self.client.send(data: payload)
-                } catch {
-                    await self.client.removeRegularResponseHandler(for: requestID)
-                    continuation.resume(throwing: error)
-                }
+        var pendingResult: Result<RegularResponseResult, Swift.Error>?
+        var continuation: CheckedContinuation<(UUID, RegularResponseResult), Swift.Error>?
+
+        try await self.client.insertRegularHandler(for: requestID) { @Sendable result in
+            let processed: Result<(UUID, RegularResponseResult), Swift.Error> = result.flatMap { payload in
+                Result { (requestID, try payload.decode(RegularResponseResult.self)) }
+            }
+
+            if let cont = continuation {
+                cont.resume(with: processed)
+            } else {
+                pendingResult = processed.map { $0.1 }
+            }
+
+            Task { await self.client.removeRegularResponseHandler(for: requestID) }
+        }
+
+        try await withTaskCancellationHandler(operation: {
+            try await self.client.send(data: payload)
+        }, onCancel: {
+            Task { await self.client.removeRegularResponseHandler(for: requestID) }
+            continuation?.resume(throwing: CancellationError())
+        })
+
+        let response = try await withCheckedThrowingContinuation { cont in
+            if let result = pendingResult {
+                cont.resume(with: result.map { (requestID, $0) })
+            } else {
+                continuation = cont
             }
         }
+
+        return response
     }
     
     /// Subscription Request
@@ -48,54 +61,63 @@ extension Fulcrum {
         let subscriptionKey = await Client.SubscriptionKey(methodPath: request.method,
                                                            identifier: self.client.getSubscriptionIdentifier(for: method))
         
-        let initialResponse: SubscriptionNotification = try await withCheckedThrowingContinuation { continuation in
-            Task {
-                do {
-                    try await self.client.insertRegularHandler(for: requestID) { @Sendable result in
-                        defer { Task { await self.client.removeRegularResponseHandler(for: requestID) } }
-                        
-                        switch result {
-                        case .success(let payload):
-                            continuation.resume(with: Result(catching: { try payload.decode(SubscriptionNotification.self) }))
-                        case .failure(let error):
-                            continuation.resume(throwing: Error.client(.unknown(error)))
-                        }
-                    }
-                    try await self.client.send(data: payload)
-                } catch {
-                    continuation.resume(throwing: error)
-                }
+        var pendingInitial: Result<SubscriptionNotification, Swift.Error>?
+        var initialContinuation: CheckedContinuation<SubscriptionNotification, Swift.Error>?
+
+        try await self.client.insertRegularHandler(for: requestID) { @Sendable result in
+            let processed: Result<SubscriptionNotification, Swift.Error> = result.flatMap { payload in
+                Result { try payload.decode(SubscriptionNotification.self) }
+            }
+
+            if let cont = initialContinuation {
+                cont.resume(with: processed)
+            } else {
+                pendingInitial = processed
+            }
+
+            Task { await self.client.removeRegularResponseHandler(for: requestID) }
+        }
+
+        var streamContinuation: AsyncThrowingStream<SubscriptionNotification, Swift.Error>.Continuation!
+        let notificationStream = AsyncThrowingStream<SubscriptionNotification, Swift.Error> { cont in
+            streamContinuation = cont
+            cont.onTermination = { @Sendable _ in
+                Task { await self.client.removeSubscriptionResponseHandler(for: subscriptionKey) }
             }
         }
-        
-        let notificationStream = AsyncThrowingStream<SubscriptionNotification, Swift.Error> { continuation in
-            Task {
+
+        try await self.client.insertSubscriptionHandler(for: subscriptionKey) { @Sendable result in
+            switch result {
+            case .success(let payload):
                 do {
-                    try await self.client.insertSubscriptionHandler(for: subscriptionKey) { @Sendable result in
-                        switch result {
-                        case .success(let payload):
-                            do {
-                                continuation.yield(try payload.decode(SubscriptionNotification.self))
-                            } catch {
-                                continuation.finish(throwing: error)
-                            }
-                        case .failure(let error):
-                            continuation.finish(throwing: Error.client(.unknown(error)))
-                        }
-                    }
+                    streamContinuation.yield(try payload.decode(SubscriptionNotification.self))
                 } catch {
-                    continuation.finish(throwing: error)
+                    streamContinuation.finish(throwing: error)
                 }
-            }
-            
-            continuation.onTermination = { @Sendable _ in
-                Task {
-                    await self.client.removeSubscriptionResponseHandler(for: subscriptionKey)
-                    // TODO: actually send "unsubscribe"
-                }
+            case .failure(let error):
+                streamContinuation.finish(throwing: Error.client(.unknown(error)))
             }
         }
-        
+
+        try await withTaskCancellationHandler(operation: {
+            try await self.client.send(data: payload)
+        }, onCancel: {
+            Task {
+                await self.client.removeRegularResponseHandler(for: requestID)
+                await self.client.removeSubscriptionResponseHandler(for: subscriptionKey)
+            }
+            streamContinuation.finish(throwing: CancellationError())
+            initialContinuation?.resume(throwing: CancellationError())
+        })
+
+        let initialResponse = try await withCheckedThrowingContinuation { cont in
+            if let initial = pendingInitial {
+                cont.resume(with: initial)
+            } else {
+                initialContinuation = cont
+            }
+        }
+
         return (requestID, initialResponse, notificationStream)
     }
 }


### PR DESCRIPTION
## Summary
- refactor `submit` methods to remove the unstructured `Task`
- hook request sending into `withTaskCancellationHandler`
- resume the continuation exactly once

## Testing
- `swift build --target SwiftFulcrum` *(fails: no such module 'Network')*
- `swift test -l` *(fails: no such module 'Network')*