### PR TITLE
Refactor Fulcrum submit to use Client

### DIFF
--- a/Sources/SwiftFulcrum/Fulcrum~Interface.swift
+++ b/Sources/SwiftFulcrum/Fulcrum~Interface.swift
@@ -6,96 +6,34 @@ extension Fulcrum {
     /// Regular Request
     public func submit<RegularResponseResult: JSONRPCConvertible>(
         method: Method,
-        responseType: RegularResponseResult.Type// = RegularResponseResult.self
-    ) async throws -> (UUID,
-                       RegularResponseResult) {
-        let requestID = UUID()
-        let request = method.createRequest(with: requestID)
-        guard let payload = request.data else { throw Error.coding(.encode(nil)) }
-        
-        return try await withCheckedThrowingContinuation { continuation in
-            Task {
-                do {
-                    try await self.client.insertRegularHandler(for: requestID) { @Sendable result in
-                        defer { Task { await self.client.removeRegularResponseHandler(for: requestID) } }
-                        
-                        switch result {
-                        case .success(let payload):
-                            continuation.resume(with: Result(catching: { (requestID, try payload.decode(RegularResponseResult.self)) }))
-                        case .failure(let error):
-                            continuation.resume(throwing: Error.client(.unknown(error)))
-                        }
-                    }
-                    try await self.client.send(data: payload)
-                } catch {
-                    await self.client.removeRegularResponseHandler(for: requestID)
-                    continuation.resume(throwing: error)
-                }
-            }
-        }
+        responseType: RegularResponseResult.Type // = RegularResponseResult.self
+    ) async throws -> RegularResponseResult {
+        let rpc: RegularResponseResult.JSONRPC = try await self.client.call(method: method)
+        return try RegularResponseResult(fromRPC: rpc)
     }
-    
+
     /// Subscription Request
     public func submit<SubscriptionNotification: JSONRPCConvertible>(
         method: Method,
-        notificationType: SubscriptionNotification.Type// = SubscriptionNotification.self
-    ) async throws -> (UUID,
-                       SubscriptionNotification,
+        notificationType: SubscriptionNotification.Type // = SubscriptionNotification.self
+    ) async throws -> (SubscriptionNotification,
                        AsyncThrowingStream<SubscriptionNotification, Swift.Error>) {
-        let requestID = UUID()
-        let request = method.createRequest(with: requestID)
-        guard let payload = request.data else { throw Error.coding(.encode(nil)) }
-        let subscriptionKey = await Client.SubscriptionKey(methodPath: request.method,
-                                                           identifier: self.client.getSubscriptionIdentifier(for: method))
-        
-        let initialResponse: SubscriptionNotification = try await withCheckedThrowingContinuation { continuation in
+        let (initialRPC, rpcStream) = try await self.client.subscribe(method: method)
+        let initial = try SubscriptionNotification(fromRPC: initialRPC)
+
+        let mappedStream = AsyncThrowingStream<SubscriptionNotification, Swift.Error> { continuation in
             Task {
                 do {
-                    try await self.client.insertRegularHandler(for: requestID) { @Sendable result in
-                        defer { Task { await self.client.removeRegularResponseHandler(for: requestID) } }
-                        
-                        switch result {
-                        case .success(let payload):
-                            continuation.resume(with: Result(catching: { try payload.decode(SubscriptionNotification.self) }))
-                        case .failure(let error):
-                            continuation.resume(throwing: Error.client(.unknown(error)))
-                        }
+                    for try await rpc in rpcStream {
+                        continuation.yield(try SubscriptionNotification(fromRPC: rpc))
                     }
-                    try await self.client.send(data: payload)
-                } catch {
-                    continuation.resume(throwing: error)
-                }
-            }
-        }
-        
-        let notificationStream = AsyncThrowingStream<SubscriptionNotification, Swift.Error> { continuation in
-            Task {
-                do {
-                    try await self.client.insertSubscriptionHandler(for: subscriptionKey) { @Sendable result in
-                        switch result {
-                        case .success(let payload):
-                            do {
-                                continuation.yield(try payload.decode(SubscriptionNotification.self))
-                            } catch {
-                                continuation.finish(throwing: error)
-                            }
-                        case .failure(let error):
-                            continuation.finish(throwing: Error.client(.unknown(error)))
-                        }
-                    }
+                    continuation.finish()
                 } catch {
                     continuation.finish(throwing: error)
                 }
             }
-            
-            continuation.onTermination = { @Sendable _ in
-                Task {
-                    await self.client.removeSubscriptionResponseHandler(for: subscriptionKey)
-                    // TODO: actually send "unsubscribe"
-                }
-            }
         }
-        
-        return (requestID, initialResponse, notificationStream)
+
+        return (initial, mappedStream)
     }
 }

--- a/Tests/SwiftFulcrumTests/FulcrumTests.swift
+++ b/Tests/SwiftFulcrumTests/FulcrumTests.swift
@@ -27,12 +27,11 @@ struct FulcrumWalletTests {
     func estimateFee() async throws {
         try await fulcrum.start()
         
-        let (id, estimateFee) = try await fulcrum.submit(
+        let estimateFee = try await fulcrum.submit(
             method: .blockchain(.estimateFee(numberOfBlocks: 6)),
             responseType: Response.Result.Blockchain.EstimateFee.self
         )
-        
-        print("ID: \(id.description)")
+
         print("Estimated fee: \(estimateFee.fee)")
         
         #expect(estimateFee.fee > 0.0)
@@ -42,12 +41,11 @@ struct FulcrumWalletTests {
     func addressBalance() async throws {
         try await fulcrum.start()
         
-        let (id, balance) = try await fulcrum.submit(
+        let balance = try await fulcrum.submit(
             method: .blockchain(.address(.getBalance(address: .sampleAddress, tokenFilter: nil))),
             responseType: Response.Result.Blockchain.Address.GetBalance.self
         )
-        
-        print("ID: \(id.description)")
+
         print("Balance: \(balance)")
         #expect(balance.confirmed >= 0)
         #expect(balance.unconfirmed >= Int64.min)
@@ -57,7 +55,7 @@ struct FulcrumWalletTests {
     func headerSubscription() async throws {
         try await fulcrum.start()
         
-        let (_, initial, stream) = try await fulcrum.submit(
+        let (initial, stream) = try await fulcrum.submit(
             method: .blockchain(.headers(.subscribe)),
             notificationType: Response.Result.Blockchain.Headers.Subscribe.self
         )

--- a/Tests/SwiftFulcrumTests/Method/Method-Blockchain-Address_Tests.swift
+++ b/Tests/SwiftFulcrumTests/Method/Method-Blockchain-Address_Tests.swift
@@ -19,7 +19,7 @@ extension MethodBlockchainAddressTests {
     @Test("address.get_balance → sane numbers")
     func getBalance() async throws {
         let balance = try await withRunningNode {
-            let (_, result) = try await fulcrum.submit(
+            let result = try await fulcrum.submit(
                 method: .blockchain(.address(.getBalance(address: address, tokenFilter: nil))),
                 responseType: Response.Result.Blockchain.Address.GetBalance.self)
             return result
@@ -34,7 +34,7 @@ extension MethodBlockchainAddressTests {
     @Test("address.get_first_use → returns a block-height")
     func getFirstUse() async throws {
         let first = try await withRunningNode {
-            let (_, result) = try await fulcrum.submit(
+            let result = try await fulcrum.submit(
                 method: .blockchain(.address(.getFirstUse(address: address))),
                 responseType: Response.Result.Blockchain.Address.GetFirstUse.self)
             return result
@@ -50,7 +50,7 @@ extension MethodBlockchainAddressTests {
     @Test("address.get_history → decodes all rows")
     func getHistory() async throws {
         let history = try await withRunningNode {
-            let (_, items) = try await fulcrum.submit(
+            let items = try await fulcrum.submit(
                 method: .blockchain(.address(.getHistory(address: address,
                                                          fromHeight: nil,
                                                          toHeight: nil,
@@ -68,7 +68,7 @@ extension MethodBlockchainAddressTests {
     @Test("address.get_mempool → decodes (may be empty)")
     func getMempool() async throws {
         let mempool = try await withRunningNode {
-            let (_, items) = try await fulcrum.submit(
+            let items = try await fulcrum.submit(
                 method: .blockchain(.address(.getMempool(address: address))),
                 responseType: Response.Result.Blockchain.Address.GetMempool.self)
             return items
@@ -82,7 +82,7 @@ extension MethodBlockchainAddressTests {
     @Test("address.get_scripthash → 64-char hex")
     func getScriptHash() async throws {
         let hash = try await withRunningNode {
-            let (_, result) = try await fulcrum.submit(
+            let result = try await fulcrum.submit(
                 method: .blockchain(.address(.getScriptHash(address: address))),
                 responseType: Response.Result.Blockchain.Address.GetScriptHash.self)
             return result
@@ -96,7 +96,7 @@ extension MethodBlockchainAddressTests {
     @Test("address.listunspent → plausible UTXOs")
     func listUnspent() async throws {
         let utxos = try await withRunningNode {
-            let (_, items) = try await fulcrum.submit(
+            let items = try await fulcrum.submit(
                 method: .blockchain(.address(.listUnspent(address: address, tokenFilter: .include))),
                 responseType: Response.Result.Blockchain.Address.ListUnspent.self)
             return items

--- a/Tests/SwiftFulcrumTests/Method/Method-Blockchain-Block&Header_Tests.swift
+++ b/Tests/SwiftFulcrumTests/Method/Method-Blockchain-Block&Header_Tests.swift
@@ -20,7 +20,7 @@ extension MethodBlockchainBlockTests {
     @Test("block.header → returns 80-byte header & branch info")
     func blockHeader() async throws {
         let header = try await withRunningNode {
-            let (_, result) = try await fulcrum.submit(
+            let result = try await fulcrum.submit(
                 method: .blockchain(.block(.header(height: height,
                                                    checkpointHeight: 1))),
                 responseType: Response.Result.Blockchain.Block.Header.self)
@@ -44,7 +44,7 @@ extension MethodBlockchainBlockTests {
     func blockHeaders() async throws {
         let range = (start: height, count: UInt(10))
         let headers = try await withRunningNode {
-            let (_, result) = try await fulcrum.submit(
+            let result = try await fulcrum.submit(
                 method: .blockchain(.block(.headers(startHeight: range.start,
                                                     count: range.count,
                                                     checkpointHeight: 0))),
@@ -62,7 +62,7 @@ extension MethodBlockchainBlockTests {
     @Test("header.get → specific block by hash")
     func headerGet() async throws {
         let header = try await withRunningNode {
-            let (_, result) = try await fulcrum.submit(
+            let result = try await fulcrum.submit(
                 method: .blockchain(.header(.get(blockHash: knownBlockHash))),
                 responseType: Response.Result.Blockchain.Header.Get.self)
             return result
@@ -77,7 +77,7 @@ extension MethodBlockchainBlockTests {
     @Test("headers.get_tip → returns current tip information")
     func headersGetTip() async throws {
         let tip = try await withRunningNode {
-            let (_, result) = try await fulcrum.submit(
+            let result = try await fulcrum.submit(
                 method: .blockchain(.headers(.getTip)),
                 responseType: Response.Result.Blockchain.Headers.GetTip.self)
             return result

--- a/Tests/SwiftFulcrumTests/Method/Method-Blockchain-Transaction_Tests.swift
+++ b/Tests/SwiftFulcrumTests/Method/Method-Blockchain-Transaction_Tests.swift
@@ -33,7 +33,7 @@ extension MethodBlockchainTransactionTests {
     @Test("transaction.get → decodes basic fields")
     func getTransaction() async throws {
         let tx = try await withRunningNode {
-            let (_, tx) = try await fulcrum.submit(
+            let tx = try await fulcrum.submit(
                 method: .blockchain(.transaction(.get(
                     transactionHash: sampleTxID,
                     verbose: true))),
@@ -52,7 +52,7 @@ extension MethodBlockchainTransactionTests {
     @Test("transaction.get_confirmed_blockhash → has height + hash")
     func confirmedBlockHash() async throws {
         let infoWithoutHeader = try await withRunningNode {
-            let (_, info) = try await fulcrum.submit(
+            let info = try await fulcrum.submit(
                 method: .blockchain(.transaction(.getConfirmedBlockHash(
                     transactionHash: sampleTxID,
                     includeHeader: false))),
@@ -69,7 +69,7 @@ extension MethodBlockchainTransactionTests {
     @Test("transaction.get_height → positive height")
     func getHeight() async throws {
         let height: UInt = try await withRunningNode {
-            let (_, h) = try await fulcrum.submit(
+            let h = try await fulcrum.submit(
                 method: .blockchain(.transaction(.getHeight(
                     transactionHash: sampleTxID))),
                 responseType: Response.Result.Blockchain.Transaction.GetHeight.self)
@@ -84,7 +84,7 @@ extension MethodBlockchainTransactionTests {
     @Test("transaction.get_merkle → returns proof branch + position")
     func getMerkle() async throws {
         let merkle = try await withRunningNode {
-            let (_, m) = try await fulcrum.submit(
+            let m = try await fulcrum.submit(
                 method: .blockchain(.transaction(.getMerkle(
                     transactionHash: sampleTxID))),
                 responseType: Response.Result.Blockchain.Transaction.GetMerkle.self)
@@ -101,7 +101,7 @@ extension MethodBlockchainTransactionTests {
     func idFromPos() async throws {
         // First, discover (height, pos) from get_merkle so the test is data-driven.
         let (height, pos) = try await withRunningNode { () async throws -> (UInt, UInt) in
-            let (_, m) = try await fulcrum.submit(
+            let m = try await fulcrum.submit(
                 method: .blockchain(.transaction(.getMerkle(
                     transactionHash: sampleTxID))),
                 responseType: Response.Result.Blockchain.Transaction.GetMerkle.self)
@@ -109,7 +109,7 @@ extension MethodBlockchainTransactionTests {
         }
         
         let roundTrip = try await withRunningNode {
-            let (_, r) = try await fulcrum.submit(
+            let r = try await fulcrum.submit(
                 method: .blockchain(.transaction(.idFromPos(
                     blockHeight: height,
                     transactionPosition: pos,

--- a/Tests/SwiftFulcrumTests/Method/Method-Blockchain_Tests.swift
+++ b/Tests/SwiftFulcrumTests/Method/Method-Blockchain_Tests.swift
@@ -18,7 +18,7 @@ extension MethodBlockchainTests {
     @Test("blockchain.estimatefee → non-zero fee")
     func estimateFee() async throws {
         let fee: Double = try await withRunningNode {
-            let (_, fee) = try await fulcrum.submit(
+            let fee = try await fulcrum.submit(
                 method: .blockchain(.estimateFee(numberOfBlocks: 6)),
                 responseType: Response.Result.Blockchain.EstimateFee.self)
             return fee.fee
@@ -33,7 +33,7 @@ extension MethodBlockchainTests {
     @Test("blockchain.relayfee → plausible default relay fee")
     func relayFee() async throws {
         let fee: Double = try await withRunningNode {
-            let (_, fee) = try await fulcrum.submit(
+            let fee = try await fulcrum.submit(
                 method: .blockchain(.relayFee),
                 responseType: Response.Result.Blockchain.RelayFee.self)
             return fee.fee
@@ -49,7 +49,7 @@ extension MethodBlockchainTests {
     func utxoGetInfo() async throws {
         let address = "qrmfkegyf83zh5kauzwgygf82sdahd5a55x9wse7ve"
         try await withRunningNode {
-            let (_, utxos) = try await fulcrum.submit(
+            let utxos = try await fulcrum.submit(
                 method: .blockchain(.address(.listUnspent(address: address,
                                                           tokenFilter: .include))),
                 responseType: Response.Result.Blockchain.Address.ListUnspent.self)
@@ -59,7 +59,7 @@ extension MethodBlockchainTests {
                 return
             }
             
-            let (_, info) = try await fulcrum.submit(
+            let info = try await fulcrum.submit(
                 method: .blockchain(.utxo(.getInfo(transactionHash: first.transactionHash,
                                                    outputIndex: UInt16(first.transactionPosition)))),
                 responseType: Response.Result.Blockchain.UTXO.GetInfo.self)
@@ -76,7 +76,7 @@ extension MethodBlockchainTests {
     @Test("mempool.get_fee_histogram → returns ≥ 1 bucket")
     func feeHistogram() async throws {
         let histogram = try await withRunningNode {
-            let (_, rows) = try await fulcrum.submit(
+            let rows = try await fulcrum.submit(
                 method: .mempool(.getFeeHistogram),
                 responseType: Response.Result.Mempool.GetFeeHistogram.self)
             return rows


### PR DESCRIPTION
## Summary
- delegate Fulcrum submit calls to `Client.call` and `Client.subscribe`
- map JSONRPC types to user-facing types
- update tests for new submit API

## Testing
- `swift test --enable-code-coverage` *(fails: no such module 'Network')*